### PR TITLE
Don't "await()" on close.

### DIFF
--- a/src/main/java/cloudfoundry/memcache/MemcacheInboundHandlerAdapter.java
+++ b/src/main/java/cloudfoundry/memcache/MemcacheInboundHandlerAdapter.java
@@ -1,15 +1,5 @@
 package cloudfoundry.memcache;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -24,12 +14,30 @@ import io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseStatus;
 import io.netty.handler.codec.memcache.binary.FullBinaryMemcacheResponse;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.GenericFutureListener;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 	
 	private static final int MAX_KEY_SIZE = 250;
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MemcacheInboundHandlerAdapter.class);
+
+	public static final GenericFutureListener<io.netty.util.concurrent.Future<Void>> FAILURE_LOGGING_LISTENER = future -> {
+		if(LOGGER.isDebugEnabled()) {
+			try {
+				future.get();
+			} catch (Exception e) {
+				LOGGER.debug("Error closing Channel. ", e);
+			}
+		}
+	};
 
 	private final MemcacheMsgHandlerFactory msgHandlerFactory;
 
@@ -84,6 +92,7 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 		ctx.channel().closeFuture().addListener(new GenericFutureListener<io.netty.util.concurrent.Future<Void>>() {
 			@Override
 			public void operationComplete(io.netty.util.concurrent.Future<Void> future) throws Exception {
+				LOGGER.info("Channel Closed for user: "+getCurrentUser());
 				try {
 					rateMonitoringScheduler.cancel(false);
 				} catch(Throwable t) {
@@ -341,11 +350,7 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 					MemcacheUtils.returnFailure(request, BinaryMemcacheResponseStatus.AUTH_ERROR, "We don't support any auth mechanisms that require a step.").send(ctx);
 				} else {
 					LOGGER.error("Received Non memcache request with SASL_STEP optcode.  This is an invalid state. Closing connection.");
-					try {
-						ctx.channel().close().await(1, TimeUnit.SECONDS);
-					} catch(Exception e) {
-						LOGGER.debug("Failure closing connection. ", e);
-					}
+					ctx.channel().close().addListener(FAILURE_LOGGING_LISTENER);
 				}
 				break;
 			default:
@@ -354,11 +359,7 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 					MemcacheUtils.returnFailure(request, BinaryMemcacheResponseStatus.UNKNOWN_COMMAND, "Unable to handle command: 0x"+Integer.toHexString(opcode)).send(ctx);
 				} else {
 					LOGGER.error("Received unsupported opcode as a non request.  This is an invalid state. Closing connection.");
-					try {
-						ctx.channel().close().await(1, TimeUnit.SECONDS);
-					} catch(Exception e) {
-						LOGGER.debug("Failure closing connection. ", e);
-					}
+					ctx.channel().close().addListener(FAILURE_LOGGING_LISTENER);
 				}
 			}
 		} catch(IllegalStateException e) {
@@ -371,11 +372,7 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 			} catch(Throwable t) { }
 		} catch(Throwable e) {
 			LOGGER.error("Error while invoking MemcacheMsgHandler.  Closing the Channel in case we're in an odd state.  Current User: "+getCurrentUser(), e);
-			try {
-				ctx.channel().close().await(1, TimeUnit.SECONDS);
-			} catch(Exception e2) {
-				LOGGER.debug("Failure closing connection. ", e2);
-			}
+			ctx.channel().close().addListener(FAILURE_LOGGING_LISTENER);
 		} finally {
 			ReferenceCountUtil.release(msg);
 		}
@@ -409,11 +406,7 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 		ctx.flush();
 		if(!msgOrderQueue.isEmpty() && System.currentTimeMillis()-msgOrderQueue.peek().getCreated() > 60000) {
 			LOGGER.warn("Message at bottom of queue has been in the queue longer than 1 mintue.  Terminating the connection.  User="+getCurrentUser());
-			try {
-				ctx.channel().close().await(1, TimeUnit.SECONDS);
-			} catch(Exception e) {
-				LOGGER.debug("Failure closing connection. ", e);
-			}
+			ctx.channel().close().addListener(FAILURE_LOGGING_LISTENER);
 			return;
 		}
 		readIfNotRateLimited(ctx);
@@ -491,16 +484,15 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 
 	@Override
 	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		if(cause instanceof CancellationException) {
+			return;
+		}
 		if(cause != null && cause.getMessage() != null && cause.getMessage().contains("Connection reset")) {
 			LOGGER.info("Channel for "+getCurrentUser()+" Unexpectedly reset.");
 		} else {
 			LOGGER.error("Unexpected Error for user: "+getCurrentUser(), cause);
 		}
-		try {
-			ctx.channel().close().await(1, TimeUnit.SECONDS);
-		} catch(Exception e) {
-			LOGGER.debug("Failure closing connection. ", e);
-		}
+		ctx.channel().close().addListener(FAILURE_LOGGING_LISTENER);
 	}
 
 	private void delayMsg(MemcacheRequestKey key, BinaryMemcacheMessage memcacheMessage, ChannelPromise promise) {

--- a/src/main/java/cloudfoundry/memcache/MemcacheMetricsPublisher.java
+++ b/src/main/java/cloudfoundry/memcache/MemcacheMetricsPublisher.java
@@ -1,14 +1,11 @@
 package cloudfoundry.memcache;
 
+import cf.dropsonde.metron.MetronClient;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import cf.dropsonde.metron.MetronClient;
 
 @Component
 public class MemcacheMetricsPublisher {

--- a/src/main/java/cloudfoundry/memcache/hazelcast/Main.java
+++ b/src/main/java/cloudfoundry/memcache/hazelcast/Main.java
@@ -1,5 +1,11 @@
 package cloudfoundry.memcache.hazelcast;
 
+import cf.dropsonde.spring.boot.EnableMetronClient;
+import cloudfoundry.memcache.AuthMsgHandlerFactory;
+import cloudfoundry.memcache.MemcacheServer;
+import cloudfoundry.memcache.MemcacheStats;
+import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
+import cloudfoundry.memcache.web.HttpBasicAuthenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -7,14 +13,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
-
-import cf.dropsonde.spring.boot.EnableMetronClient;
-import cloudfoundry.memcache.AuthMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheServer;
-import cloudfoundry.memcache.MemcacheStats;
-import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
-import cloudfoundry.memcache.web.HttpBasicAuthenticator;
 
 @SpringBootApplication
 @ComponentScan("cloudfoundry.memcache")

--- a/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheSpyTest.java
+++ b/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheSpyTest.java
@@ -3,44 +3,28 @@ package cloudfoundry.memcache.hazelcast;
 import static org.junit.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
+import cloudfoundry.memcache.MemcacheServer;
+import cloudfoundry.memcache.MemcacheStats;
+import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
-
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
-import net.spy.memcached.DefaultConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.auth.PlainCallbackHandler;
-import net.spy.memcached.internal.GetFuture;
-import net.spy.memcached.internal.OperationCompletionListener;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.ops.StatusCode;
-import net.spy.memcached.transcoders.SerializingTranscoder;
-
 import org.apache.commons.lang.RandomStringUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheMsgHandlerFactoryAuthStub;
-import cloudfoundry.memcache.MemcacheServer;
-import cloudfoundry.memcache.MemcacheStats;
-import cloudfoundry.memcache.SecretKeyAuthMsgHandler;
-import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
-import cloudfoundry.memcache.StubAuthMsgHandlerFactory;
-import io.netty.util.CharsetUtil;
-
-import com.hazelcast.config.Config;
 
 
 public class HazelcastMemcacheSpyTest {

--- a/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheStatsTest.java
+++ b/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheStatsTest.java
@@ -1,38 +1,21 @@
 package cloudfoundry.memcache.hazelcast;
 
-import static org.junit.Assert.assertEquals;
-
+import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
+import cloudfoundry.memcache.MemcacheServer;
+import cloudfoundry.memcache.MemcacheStats;
+import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
 import java.net.ServerSocket;
-import java.net.SocketAddress;
 import java.util.Collections;
-import java.util.Map;
-import java.util.Random;
-
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.auth.PlainCallbackHandler;
-import net.spy.memcached.internal.OperationCompletionListener;
-import net.spy.memcached.internal.OperationFuture;
-import net.spy.memcached.ops.StatusCode;
-import net.spy.memcached.transcoders.SerializingTranscoder;
-
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheMsgHandlerFactoryAuthStub;
-import cloudfoundry.memcache.MemcacheServer;
-import cloudfoundry.memcache.MemcacheStats;
-import cloudfoundry.memcache.SecretKeyAuthMsgHandler;
-import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
-import cloudfoundry.memcache.StubAuthMsgHandlerFactory;
-
-import com.hazelcast.config.Config;
 
 
 public class HazelcastMemcacheStatsTest {

--- a/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheWhalinTest.java
+++ b/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheWhalinTest.java
@@ -1,31 +1,22 @@
 package cloudfoundry.memcache.hazelcast;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
+import cloudfoundry.memcache.MemcacheServer;
+import cloudfoundry.memcache.MemcacheStats;
+import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
+import com.schooner.MemCached.AuthInfo;
+import com.schooner.MemCached.SchoonerSockIOPool;
+import com.whalin.MemCached.MemCachedClient;
 import java.net.ServerSocket;
 import java.util.Collections;
-import java.util.Random;
-
 import org.apache.commons.lang.RandomStringUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheMsgHandlerFactoryAuthStub;
-import cloudfoundry.memcache.MemcacheServer;
-import cloudfoundry.memcache.MemcacheStats;
-import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
-import cloudfoundry.memcache.StubAuthMsgHandlerFactory;
-import io.netty.util.CharsetUtil;
-
-import com.hazelcast.config.Config;
-import com.schooner.MemCached.AuthInfo;
-import com.schooner.MemCached.SchoonerSockIOPool;
-import com.whalin.MemCached.MemCachedClient;
 
 
 public class HazelcastMemcacheWhalinTest {

--- a/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheXMemcachedTest.java
+++ b/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheXMemcachedTest.java
@@ -1,35 +1,23 @@
 package cloudfoundry.memcache.hazelcast;
 
-import static org.testng.Assert.assertTrue;
-
+import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
+import cloudfoundry.memcache.MemcacheServer;
+import cloudfoundry.memcache.MemcacheStats;
+import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-
 import net.rubyeye.xmemcached.MemcachedClient;
 import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.command.BinaryCommandFactory;
 import net.rubyeye.xmemcached.utils.AddrUtil;
-import net.spy.memcached.internal.OperationFuture;
-
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheMsgHandlerFactoryAuthStub;
-import cloudfoundry.memcache.MemcacheServer;
-import cloudfoundry.memcache.MemcacheStats;
-import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
-import cloudfoundry.memcache.StubAuthMsgHandlerFactory;
-import io.netty.util.CharsetUtil;
-
-import com.hazelcast.config.Config;
 
 
 public class HazelcastMemcacheXMemcachedTest {
@@ -57,12 +45,6 @@ public class HazelcastMemcacheXMemcachedTest {
 		while(!factory.status().equals(MemcacheMsgHandlerFactory.OK_STATUS)) {
 			Thread.sleep(1000);
 		}
-
-		String[] servers =
-			{
-//			  "localhost:"+localPort,
-			  "localhost:11211",
-			};
 
 		List<InetSocketAddress> addresses = AddrUtil.getAddresses("localhost:"+localPort);
 		XMemcachedClientBuilder builder = new XMemcachedClientBuilder("localhost:"+localPort);

--- a/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcapableTest.java
+++ b/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcapableTest.java
@@ -1,19 +1,15 @@
 package cloudfoundry.memcache.hazelcast;
 
-import java.net.ServerSocket;
-import java.util.Collections;
-
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import com.hazelcast.config.Config;
-
 import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
 import cloudfoundry.memcache.MemcacheServer;
 import cloudfoundry.memcache.MemcacheStats;
 import cloudfoundry.memcache.StubAuthMsgHandlerFactory;
+import java.net.ServerSocket;
+import java.util.Collections;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class HazelcastMemcapableTest {
 


### PR DESCRIPTION
On errors the code was "await()" ing for 1 second.  This is bad because it blocks one of the minimal processing threads which should not be blocked ever.  So, this change removes that block with a callback that logs any errors that may have happened without blocking.

I also did some minimal elimination of compiler warnings.