### PR TITLE
Cleanup startup shutdown logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 			<groupId>net.spy</groupId>
 			<artifactId>spymemcached</artifactId>
 			<version>2.12.1</version>
-<!-- 			<scope>test</scope>
- -->		</dependency>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.googlecode.xmemcached</groupId>
 			<artifactId>xmemcached</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>compile</scope>
@@ -85,12 +89,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-			<version>6.8.21</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.easymock</groupId>
 			<artifactId>easymock</artifactId>
 			<version>3.3.1</version>
@@ -104,6 +102,11 @@
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
 			<version>2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 			<groupId>net.spy</groupId>
 			<artifactId>spymemcached</artifactId>
 			<version>2.12.1</version>
-			<scope>test</scope>
-		</dependency>
+<!-- 			<scope>test</scope>
+ -->		</dependency>
 		<dependency>
 			<groupId>com.googlecode.xmemcached</groupId>
 			<artifactId>xmemcached</artifactId>

--- a/src/main/java/cloudfoundry/memcache/MemcacheInboundHandlerAdapter.java
+++ b/src/main/java/cloudfoundry/memcache/MemcacheInboundHandlerAdapter.java
@@ -1,15 +1,5 @@
 package cloudfoundry.memcache;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -24,6 +14,13 @@ import io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseStatus;
 import io.netty.handler.codec.memcache.binary.FullBinaryMemcacheResponse;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.GenericFutureListener;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 	
@@ -362,13 +359,7 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 				}
 			}
 		} catch(IllegalStateException e) {
-			LOGGER.error("IllegalStateException thrown.  Shutting down the server because we don't know the state we're in.", e);
-			try {
-				msgHandlerFactory.shutdown();
-			} catch(Throwable t) { }
-			try {
-				memcacheServer.shutdown();
-			} catch(Throwable t) { }
+			ShutdownUtils.gracefullyExit("IllegalStateException thrown.  Shutting down the server because we don't know the state we're in.", (byte)99, e);
 		} catch(Throwable e) {
 			LOGGER.error("Error while invoking MemcacheMsgHandler.  Closing the Channel in case we're in an odd state.  Current User: "+getCurrentUser(), e);
 			try {

--- a/src/main/java/cloudfoundry/memcache/MemcacheInboundHandlerAdapter.java
+++ b/src/main/java/cloudfoundry/memcache/MemcacheInboundHandlerAdapter.java
@@ -92,11 +92,10 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 		ctx.channel().closeFuture().addListener(new GenericFutureListener<io.netty.util.concurrent.Future<Void>>() {
 			@Override
 			public void operationComplete(io.netty.util.concurrent.Future<Void> future) throws Exception {
-				LOGGER.info("Channel Closed for user: "+getCurrentUser());
 				try {
 					rateMonitoringScheduler.cancel(false);
 				} catch(Throwable t) {
-					LOGGER.error("Rate monitoring scheduled task.", t);
+					LOGGER.error("Error cancelling rate monitoring scheduled task.", t);
 				}
 				clearDelayedMessages();
 			}
@@ -364,6 +363,7 @@ public class MemcacheInboundHandlerAdapter extends ChannelDuplexHandler {
 			}
 		} catch(IllegalStateException e) {
 			ShutdownUtils.gracefullyExit("IllegalStateException thrown.  Shutting down the server because we don't know the state we're in.", (byte)99, e);
+			ctx.channel().close().addListener(FAILURE_LOGGING_LISTENER);
 		} catch(Throwable e) {
 			LOGGER.error("Error while invoking MemcacheMsgHandler.  Closing the Channel in case we're in an odd state.  Current User: "+getCurrentUser(), e);
 			ctx.channel().close().addListener(FAILURE_LOGGING_LISTENER);

--- a/src/main/java/cloudfoundry/memcache/MemcacheMsgHandlerFactory.java
+++ b/src/main/java/cloudfoundry/memcache/MemcacheMsgHandlerFactory.java
@@ -8,8 +8,6 @@ public interface MemcacheMsgHandlerFactory {
 	public static final String OK_STATUS = "OK";
 	public MemcacheMsgHandler createMsgHandler(BinaryMemcacheRequest request, AuthMsgHandler authMsgHandler);
 	public void deleteCache(String name);
-	public void shutdown();
-	public void shutdownNow();
 	public ScheduledExecutorService getScheduledExecutorService();
 	public String status();
 	boolean isCacheValid(String cacheName);

--- a/src/main/java/cloudfoundry/memcache/MemcacheStatusHandlerMapping.java
+++ b/src/main/java/cloudfoundry/memcache/MemcacheStatusHandlerMapping.java
@@ -1,11 +1,9 @@
 package cloudfoundry.memcache;
 
 import java.io.IOException;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.HttpRequestHandler;

--- a/src/main/java/cloudfoundry/memcache/ShutdownUtils.java
+++ b/src/main/java/cloudfoundry/memcache/ShutdownUtils.java
@@ -1,0 +1,87 @@
+package cloudfoundry.memcache;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ShutdownUtils {
+	@FunctionalInterface
+	public interface CheckedRunnable {
+		void run() throws Exception;
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(ShutdownUtils.class);
+
+	private static volatile boolean shutdownStarted = false;
+
+	private ShutdownUtils() {
+	}
+
+	public static synchronized void gracefullyExit(String msg, byte code, Throwable cause) {
+		Throwable loggedCause;
+		if (cause != null) {
+			loggedCause = cause;
+		} else {
+			loggedCause = new Exception("No cause provided but this Exception provides the trace that got us here.");
+		}
+		synchronized (ShutdownUtils.class) {
+			if (!shutdownStarted) {
+				LOG.error("Shutting down app with code={} and msg={}", code, msg, loggedCause);
+				new Thread(() -> System.exit(code)).start();
+				shutdownStarted = true;
+			}
+		}
+	}
+
+	/**
+	 * Executes the closeTask catching any exception thrown and logging a warning
+	 * and a debug message on failure.
+	 *
+	 * @param closeTask
+	 * @param log
+	 * @param failureMsg
+	 */
+	public static void safeClose(CheckedRunnable closeTask, Logger log, String failureMsg) {
+		try {
+			closeTask.run();
+		} catch (Exception e) {
+			log.warn("{}.  See debug log for details.", failureMsg);
+			log.debug(failureMsg, e);
+		}
+	}
+
+	/**
+	 * Gracefully closes the executor service and logs when we have to interrupt.
+	 *
+	 * @param executorService         the service that we are trying to close.
+	 * @param awaitTerminationTimeOut the duration we check if the executor service
+	 *                                is waiting for.
+	 * @param giveupTimeout           the amount of time that is appropriate for us
+	 *                                to wait for the service to close before we
+	 *                                interrupt.
+	 */
+	public static void gracefullyCloseExecutorService(ExecutorService executorService, Duration awaitTerminationTimeOut,
+			Duration giveupTimeout) {
+		executorService.shutdown();
+		try {
+			if (!executorService.awaitTermination(awaitTerminationTimeOut.toMillis(), TimeUnit.MILLISECONDS)) {
+				long giveUpTime = System.currentTimeMillis() + giveupTimeout.toMillis();
+				LOG.warn("Await termination time expired.  Attempting to interrupt every 500ms for {}", giveupTimeout);
+				do {
+					executorService.shutdownNow();
+				} while (!executorService.awaitTermination(500, TimeUnit.MILLISECONDS)
+						&& giveUpTime > System.currentTimeMillis());
+				if (!executorService.isTerminated()) {
+
+					LOG.error("Failed to terminate all threads, gave up.");
+				}
+			}
+
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+}

--- a/src/main/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheMsgHandlerFactory.java
+++ b/src/main/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheMsgHandlerFactory.java
@@ -1,17 +1,9 @@
 package cloudfoundry.memcache.hazelcast;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.PreDestroy;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import cloudfoundry.memcache.AuthMsgHandler;
+import cloudfoundry.memcache.MemcacheMsgHandler;
+import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
+import cloudfoundry.memcache.ShutdownUtils;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionPolicy;
@@ -28,8 +20,6 @@ import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.PartitionGroupConfig.MemberGroupType;
-import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.config.QuorumListenerConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.TcpIpConfig;
@@ -39,37 +29,38 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.quorum.QuorumEvent;
-import com.hazelcast.quorum.QuorumListener;
-
-import cloudfoundry.memcache.AuthMsgHandler;
-import cloudfoundry.memcache.MemcacheMsgHandler;
-import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheServer;
 import io.netty.handler.codec.memcache.binary.BinaryMemcacheRequest;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class HazelcastMemcacheMsgHandlerFactory implements MemcacheMsgHandlerFactory {
+public class HazelcastMemcacheMsgHandlerFactory implements MemcacheMsgHandlerFactory, AutoCloseable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(HazelcastMemcacheMsgHandlerFactory.class);
-	private static final String MEMCACHE_QUORUM_RULE = "memcacheQuorumRule";
 	public static final String EXECUTOR_INSTANCE_NAME = "memcache";
 	public static final String DELETED_CACHES_KEY = "deletedCachesKey";
 
-	private HazelcastInstance instance;
-	private ScheduledExecutorService memoryTrimmerExecutor;
-	private ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(4);
+	private final HazelcastInstance instance;
+	private final ScheduledExecutorService memoryTrimmerExecutor;
+	private final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(4);
 	private volatile boolean shuttingDown = false;
 	private final MemcacheHazelcastConfig appConfig;
 
-	public HazelcastMemcacheMsgHandlerFactory(MemcacheServer memcacheServer, MemcacheHazelcastConfig appConfig) {
+	public HazelcastMemcacheMsgHandlerFactory(MemcacheHazelcastConfig appConfig) {
 		this.appConfig = appConfig;
 		Config config = new Config();
 		for (Map.Entry<String, MemcacheHazelcastConfig.Plan> plan : appConfig.getPlans().entrySet()) {
-			LOGGER.info("Configuring plan: " + plan.getKey());
+			LOGGER.info("Configuring plan: {}", plan.getKey());
 			MapConfig mapConfig = new MapConfig(plan.getKey() + "*");
 			mapConfig.setStatisticsEnabled(true);
 			mapConfig.setBackupCount(plan.getValue().getBackup());
 			mapConfig.setAsyncBackupCount(plan.getValue().getAsyncBackup());
-			if(plan.getValue().getEvictionPolicy() == EvictionPolicy.LRU) {
+			if (plan.getValue().getEvictionPolicy() == EvictionPolicy.LRU) {
 				mapConfig.setMapEvictionPolicy(LRUCreatedOrUpdateEvictionPolicy.INSTANCE);
 			} else {
 				mapConfig.setEvictionPolicy(plan.getValue().getEvictionPolicy());
@@ -92,7 +83,7 @@ public class HazelcastMemcacheMsgHandlerFactory implements MemcacheMsgHandlerFac
 		}
 		NetworkConfig networkConfig = new NetworkConfig().setReuseAddress(true);
 		config.setNetworkConfig(networkConfig);
-		if(appConfig.getHazelcast().getPort() != null) {
+		if (appConfig.getHazelcast().getPort() != null) {
 			networkConfig.setPort(appConfig.getHazelcast().getPort());
 		}
 		networkConfig.setPortAutoIncrement(false);
@@ -121,237 +112,172 @@ public class HazelcastMemcacheMsgHandlerFactory implements MemcacheMsgHandlerFac
 		config.setProperty("hazelcast.backpressure.enabled", "true");
 		config.setProperty("hazelcast.jmx", "true");
 		setPropertyIfNotNull(config, "hazelcast.io.thread.count", appConfig.getHazelcast().getIoThreadCount());
-		setPropertyIfNotNull(config, "hazelcast.operation.thread.count", appConfig.getHazelcast().getOperationThreadCount());
-		setPropertyIfNotNull(config, "hazelcast.operation.generic.thread.count", appConfig.getHazelcast().getOperationGenericThreadCount());
+		setPropertyIfNotNull(config, "hazelcast.operation.thread.count",
+				appConfig.getHazelcast().getOperationThreadCount());
+		setPropertyIfNotNull(config, "hazelcast.operation.generic.thread.count",
+				appConfig.getHazelcast().getOperationGenericThreadCount());
 		setPropertyIfNotNull(config, "hazelcast.event.thread.count", appConfig.getHazelcast().getEventThreadCount());
-		setPropertyIfNotNull(config, "hazelcast.client.event.thread.count", appConfig.getHazelcast().getClientEventThreadCount());
+		setPropertyIfNotNull(config, "hazelcast.client.event.thread.count",
+				appConfig.getHazelcast().getClientEventThreadCount());
 		setPropertyIfNotNull(config, "hazelcast.partition.count", appConfig.getHazelcast().getPartitionCount());
-		setPropertyIfNotNull(config, "hazelcast.max.no.heartbeat.seconds", appConfig.getHazelcast().getMaxNoHeartbeatSeconds());
-		setPropertyIfNotNull(config, "hazelcast.operation.call.timeout.millis", appConfig.getHazelcast().getOperationCallTimeout());
-		setPropertyIfNotNull(config, "hazelcast.socket.receive.buffer.size", appConfig.getHazelcast().getReceiveBufferSize());
+		setPropertyIfNotNull(config, "hazelcast.max.no.heartbeat.seconds",
+				appConfig.getHazelcast().getMaxNoHeartbeatSeconds());
+		setPropertyIfNotNull(config, "hazelcast.operation.call.timeout.millis",
+				appConfig.getHazelcast().getOperationCallTimeout());
+		setPropertyIfNotNull(config, "hazelcast.socket.receive.buffer.size",
+				appConfig.getHazelcast().getReceiveBufferSize());
 		setPropertyIfNotNull(config, "hazelcast.socket.send.buffer.size", appConfig.getHazelcast().getSendBufferSize());
 		config.setProperty("hazelcast.socket.connect.timeout.seconds", "30");
 		config.setProperty("hazelcast.slow.operation.detector.enabled", "false");
 		config.setProperty("hazelcast.diagnostics.enabled", "false");
-		setPropertyIfNotNull(config, "hazelcast.partition.migration.timeout", appConfig.getHazelcast().getMaxNoHeartbeatSeconds());
-		setPropertyIfNotNull(config, "hazelcast.graceful.shutdown.max.wait", appConfig.getHazelcast().getLocalMemberSafeTimeout());
+		setPropertyIfNotNull(config, "hazelcast.partition.migration.timeout",
+				appConfig.getHazelcast().getMaxNoHeartbeatSeconds());
+		setPropertyIfNotNull(config, "hazelcast.graceful.shutdown.max.wait",
+				appConfig.getHazelcast().getLocalMemberSafeTimeout());
 		config.setProperty("hazelcast.max.join.seconds", "30");
 		config.setProperty("hazelcast.max.no.master.confirmation.seconds", "60");
 		config.setProperty("hazelcast.member.list.publish.interval.seconds", "90");
 		config.setProperty("hazelcast.map.invalidation.batch.enabled", "false");
 		config.addListenerConfig(new ListenerConfig(new ShutdownListener()));
-		QuorumConfig quorumConfig = null;
-		if(appConfig.getHazelcast().getMinimumClusterMembers() != null && appConfig.getHazelcast().getMinimumClusterMembers() > 1) {
-			QuorumListenerConfig listenerConfig = new QuorumListenerConfig();
-			listenerConfig.setImplementation(new QuorumListener() {
-				@Override
-				public void onChange(QuorumEvent quorumEvent) {
-					try {
-						if (quorumEvent.isPresent()) {
-							if(appConfig.getHazelcast().getEnableMemoryTrimmer()) {
-								if(memoryTrimmerExecutor == null) {
-									memoryTrimmerExecutor = Executors.newScheduledThreadPool(1);
-									memoryTrimmerExecutor.scheduleWithFixedDelay(new MaxHeapTrimmer(HazelcastMemcacheMsgHandlerFactory.this, appConfig.getHazelcast().getMaxCacheSize(), appConfig.getHazelcast().getPercentToTrim()), appConfig.getHazelcast().getTrimDelay(), appConfig.getHazelcast().getTrimDelay(), TimeUnit.SECONDS);
-								}
-							}
-							memcacheServer.start(HazelcastMemcacheMsgHandlerFactory.this);
-						} else {
-							memcacheServer.shutdown();
-							if(memoryTrimmerExecutor != null) {
-								memoryTrimmerExecutor.shutdownNow();
-								memoryTrimmerExecutor = null;
-							}
-						}
-					} catch(Exception e) {
-						LOGGER.error("Unexpected Error in QuorumListener.  Shutting Down Hazelcast.", e);
-						System.exit(1);
-					}
-				}
-			});
-			quorumConfig = new QuorumConfig();
-			quorumConfig.setName(MEMCACHE_QUORUM_RULE);
-			quorumConfig.setEnabled(true);
-			quorumConfig.setSize(appConfig.getHazelcast().getMinimumClusterMembers());
-			quorumConfig.addListenerConfig(listenerConfig);
-			config.addQuorumConfig(quorumConfig);
-			for(MapConfig entry : config.getMapConfigs().values()) {
-				entry.setQuorumName(MEMCACHE_QUORUM_RULE);
-			}
-		} else {
-			config.addListenerConfig(new ListenerConfig(new LifecycleListener() {
-				
-				@Override
-				public void stateChanged(LifecycleEvent event) {
-					try {
-						if(LifecycleState.STARTED.equals(event.getState())) {
-							if(appConfig.getHazelcast().getEnableMemoryTrimmer()) {
-								if(memoryTrimmerExecutor == null) {
-									memoryTrimmerExecutor = Executors.newScheduledThreadPool(1);
-									memoryTrimmerExecutor.scheduleWithFixedDelay(new MaxHeapTrimmer(HazelcastMemcacheMsgHandlerFactory.this, appConfig.getHazelcast().getMaxCacheSize(), appConfig.getHazelcast().getPercentToTrim()), appConfig.getHazelcast().getTrimDelay(), appConfig.getHazelcast().getTrimDelay(), TimeUnit.SECONDS);
-								}
-							}
-							memcacheServer.start(HazelcastMemcacheMsgHandlerFactory.this);
-						}
-						if(LifecycleState.SHUTTING_DOWN.equals(event.getState())) {
-							memcacheServer.shutdown();
-							if(memoryTrimmerExecutor != null) {
-								memoryTrimmerExecutor.shutdownNow();
-								memoryTrimmerExecutor = null;
-							}
-						}
-					} catch(Exception e) {
-						LOGGER.error("Unexpected Error in LifecycleListener.  Shutting Down Hazelcast.", e);
-						System.exit(1);
-					}
-				}
-			}));
-		}
 
-		SerializerConfig serializerConfig = new SerializerConfig().setImplementation(new HazelcastMemcacheCacheValueSerializer()).setTypeClass(
-				HazelcastMemcacheCacheValue.class);
+		SerializerConfig serializerConfig = new SerializerConfig()
+				.setImplementation(new HazelcastMemcacheCacheValueSerializer())
+				.setTypeClass(HazelcastMemcacheCacheValue.class);
 		config.getSerializationConfig().addSerializerConfig(serializerConfig);
 		setupSerializables(config);
 		config.addReplicatedMapConfig(new ReplicatedMapConfig().setName(Stat.STAT_MAP));
 
-		ExecutorConfig executorConfig = new ExecutorConfig().setStatisticsEnabled( false );
-		if(appConfig.getHazelcast().getExecutorPoolSize() == null || appConfig.getHazelcast().getExecutorPoolSize() == 0) {
-			executorConfig.setPoolSize(Runtime.getRuntime().availableProcessors()*2);
+		ExecutorConfig executorConfig = new ExecutorConfig().setStatisticsEnabled(false);
+		if (appConfig.getHazelcast().getExecutorPoolSize() == null
+				|| appConfig.getHazelcast().getExecutorPoolSize() == 0) {
+			executorConfig.setPoolSize(Runtime.getRuntime().availableProcessors() * 2);
 		} else {
 			executorConfig.setPoolSize(appConfig.getHazelcast().getExecutorPoolSize());
 		}
-		
+
 		config.setExecutorConfigs(Collections.singletonMap(EXECUTOR_INSTANCE_NAME, executorConfig));
 
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					instance = Hazelcast.newHazelcastInstance(config);
-					LOGGER.info("Hazelcast Started.");
-					instance.getReplicatedMap(Stat.STAT_MAP).putIfAbsent(Stat.UPTIME_KEY, System.currentTimeMillis());
-				} catch(Throwable t) {
-					LOGGER.error("Error attempting to start Hazelcast.  Shutting Down.", t);
-					System.exit(1);
-				}
+		instance = Hazelcast.newHazelcastInstance(config);
+		LOGGER.info("Hazelcast Started.");
+		instance.getReplicatedMap(Stat.STAT_MAP).putIfAbsent(Stat.UPTIME_KEY, System.currentTimeMillis());
+		if (appConfig.getHazelcast().getEnableMemoryTrimmer().booleanValue()) {
+			try {
+				memoryTrimmerExecutor = Executors.newScheduledThreadPool(1);
+				memoryTrimmerExecutor.scheduleWithFixedDelay(new MaxHeapTrimmer(HazelcastMemcacheMsgHandlerFactory.this,
+						appConfig.getHazelcast().getMaxCacheSize(), appConfig.getHazelcast().getPercentToTrim()),
+						appConfig.getHazelcast().getTrimDelay(), appConfig.getHazelcast().getTrimDelay(),
+						TimeUnit.SECONDS);
+			} catch (Exception e) {
+				instance.shutdown();
+				throw e;
 			}
-		}).start();
+		} else {
+			memoryTrimmerExecutor = null;
+		}
 	}
-	
+
 	private class ShutdownListener implements LifecycleListener {
 		@Override
 		public void stateChanged(LifecycleEvent event) {
-			if(LifecycleState.SHUTDOWN.equals(event.getState())) {
-				LOGGER.info("Hazelcast Server is shutdown.");
-				if(!shuttingDown) {
-					LOGGER.info("Irregular shutdown detected.  Exiting the process.");
-					System.exit(1);
+			if (LifecycleState.SHUTDOWN.equals(event.getState())) {
+				if (!shuttingDown) {
+					ShutdownUtils.gracefullyExit("Irregular shutdown detected.  Exiting the process.", (byte) 101,
+							null);
+				} else {
+					LOGGER.info("Hazelcast Server is shutdown.");
 				}
 			}
 		}
 	}
-	
+
 	private void setPropertyIfNotNull(Config config, String property, Object value) {
-		if(value != null) {
+		if (value != null) {
 			config.setProperty(property, value.toString());
 		}
 	}
-	
+
 	public HazelcastInstance getInstance() {
 		return instance;
 	}
 
 	private void setupSerializables(Config config) {
-		config.getSerializationConfig().addDataSerializableFactory(2, (int id) -> (id == 2) ? new HazelcastSetCallable() : null);
-		config.getSerializationConfig().addDataSerializableFactory(3, (int id) -> (id == 3) ? new HazelcastMemcacheMessage() : null);
-		config.getSerializationConfig().addDataSerializableFactory(4, (int id) -> (id == 4) ? new HazelcastDeleteCallable() : null);
-		config.getSerializationConfig().addDataSerializableFactory(5, (int id) -> (id == 5) ? new HazelcastIncDecCallable() : null);
-		config.getSerializationConfig().addDataSerializableFactory(6, (int id) -> (id == 6) ? new HazelcastAppendPrependCallable() : null);
-		config.getSerializationConfig().addDataSerializableFactory(7, (int id) -> (id == 7) ? new HazelcastTouchCallable() : null);
-		config.getSerializationConfig().addDataSerializableFactory(8, (int id) -> (id == 8) ? new HazelcastGATCallable() : null);
+		config.getSerializationConfig().addDataSerializableFactory(2,
+				(int id) -> (id == 2) ? new HazelcastSetCallable() : null);
+		config.getSerializationConfig().addDataSerializableFactory(3,
+				(int id) -> (id == 3) ? new HazelcastMemcacheMessage() : null);
+		config.getSerializationConfig().addDataSerializableFactory(4,
+				(int id) -> (id == 4) ? new HazelcastDeleteCallable() : null);
+		config.getSerializationConfig().addDataSerializableFactory(5,
+				(int id) -> (id == 5) ? new HazelcastIncDecCallable() : null);
+		config.getSerializationConfig().addDataSerializableFactory(6,
+				(int id) -> (id == 6) ? new HazelcastAppendPrependCallable() : null);
+		config.getSerializationConfig().addDataSerializableFactory(7,
+				(int id) -> (id == 7) ? new HazelcastTouchCallable() : null);
+		config.getSerializationConfig().addDataSerializableFactory(8,
+				(int id) -> (id == 8) ? new HazelcastGATCallable() : null);
 	}
 
 	public MemcacheMsgHandler createMsgHandler(BinaryMemcacheRequest request, AuthMsgHandler authMsgHandler) {
-		return new HazelcastMemcacheMsgHandler(request, authMsgHandler, instance, appConfig.getMemcache().getMaxValueSize());
+		return new HazelcastMemcacheMsgHandler(request, authMsgHandler, instance,
+				appConfig.getMemcache().getMaxValueSize());
 	}
-	
+
 	public boolean isCacheValid(String cacheName) {
-		if(instance == null || instance.getReplicatedMap(DELETED_CACHES_KEY) == null) {
+		if (instance == null || instance.getReplicatedMap(DELETED_CACHES_KEY) == null) {
 			return false;
 		}
 		return !instance.getReplicatedMap(DELETED_CACHES_KEY).containsKey(cacheName);
 	}
 
 	public void deleteCache(String name) {
-		//I know this isn't a great solution but is better than it was. :)
+		// I know this isn't a great solution but is better than it was. :)
 		instance.getReplicatedMap(DELETED_CACHES_KEY).put(name, "");
 		IMap<Object, Object> map = instance.getMap(name);
-		if(map != null) {
-			LOGGER.info("Destroying cache: "+name);
+		if (map != null) {
+			LOGGER.info("Destroying cache: " + name);
 			map.destroy();
 		}
 	}
-	
+
 	@Override
 	public ScheduledExecutorService getScheduledExecutorService() {
 		return scheduledExecutorService;
 	}
-	
+
 	@Override
 	public String status() {
-		if(shuttingDown)  {
+		if (shuttingDown) {
 			return "Shuttingdown";
 		}
-		if(instance == null) {
+		if (instance == null) {
 			return "InstanceNull";
 		}
-		if(!instance.getLifecycleService().isRunning()) {
+		if (!instance.getLifecycleService().isRunning()) {
 			return "NotRunning";
 		}
-		if(instance.getCluster().getClusterState() != ClusterState.ACTIVE) {
-			return "ClusterNotActive: "+instance.getCluster().getClusterState();
+		if (instance.getCluster().getClusterState() != ClusterState.ACTIVE) {
+			return "ClusterNotActive: " + instance.getCluster().getClusterState();
 		}
-		if(!instance.getPartitionService().isClusterSafe()) {
+		if (!instance.getPartitionService().isClusterSafe()) {
 			return "ClusterNotSafe";
 		}
-		if(!instance.getPartitionService().isLocalMemberSafe()) {
+		if (!instance.getPartitionService().isLocalMemberSafe()) {
 			return "LocalMemberNotSafe";
 		}
 		return OK_STATUS;
 	}
 
-	@PreDestroy
-	public void shutdown() {
-		if(!shuttingDown) {
+	@Override
+	public void close() throws Exception {
+		if (memoryTrimmerExecutor != null) {
+			memoryTrimmerExecutor.shutdownNow();
+		}
+		if (!shuttingDown) {
 			shuttingDown = true;
 			LOGGER.info("Shutting down Hazelcast.");
-			if(scheduledExecutorService != null) {
-				try {
-					scheduledExecutorService.shutdown();
-				} catch(Exception e) {
-					LOGGER.warn("Unexpected error attempting to shutdown Executor. Ignoring.", e);
-				}
-			}
-			if(instance != null) {
-				instance.shutdown();
-			}
+			ShutdownUtils.gracefullyCloseExecutorService(scheduledExecutorService, Duration.ofSeconds(5),
+					Duration.ofSeconds(5));
+			instance.shutdown();
 		}
 	}
-
-	public void shutdownNow() {
-		if(!shuttingDown) {
-			LOGGER.info("Terminating Hazelcast.");
-			shuttingDown = true;
-			if(scheduledExecutorService != null) {
-				try {
-					scheduledExecutorService.shutdownNow();
-				} catch(Exception e) {
-					LOGGER.warn("Unexpected error attempting to shutdown Executor. Ignoring.", e);
-				}
-			}
-			if(instance != null) {
-				instance.getLifecycleService().terminate();
-			}
-		}
-	}
-
 }

--- a/src/main/java/cloudfoundry/memcache/hazelcast/MemcacheHazelcastConfig.java
+++ b/src/main/java/cloudfoundry/memcache/hazelcast/MemcacheHazelcastConfig.java
@@ -1,19 +1,16 @@
 package cloudfoundry.memcache.hazelcast;
 
+import com.hazelcast.config.EvictionPolicy;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-
-import com.hazelcast.config.EvictionPolicy;
 
 @Component
 @ConfigurationProperties
@@ -153,7 +150,6 @@ public class MemcacheHazelcastConfig {
 	public static class Hazelcast {
 		@NotNull Integer port;
 		@NotNull Integer localMemberSafeTimeout;
-		@NotNull Integer minimumClusterMembers;
 		@NotNull Integer executorPoolSize;
 		@NotNull Boolean enableMemoryTrimmer = Boolean.FALSE;
 		@NotNull Long maxCacheSize;
@@ -182,12 +178,6 @@ public class MemcacheHazelcastConfig {
 		}
 		public void setLocalMemberSafeTimeout(Integer localMemberSafeTimeout) {
 			this.localMemberSafeTimeout = localMemberSafeTimeout;
-		}
-		public Integer getMinimumClusterMembers() {
-			return minimumClusterMembers;
-		}
-		public void setMinimumClusterMembers(Integer minimumClusterMembers) {
-			this.minimumClusterMembers = minimumClusterMembers;
 		}
 		public Integer getExecutorPoolSize() {
 			return executorPoolSize;

--- a/src/test/java/cloudfoundry/memcache/MemcacheMsgHandlerFactoryAuthStub.java
+++ b/src/test/java/cloudfoundry/memcache/MemcacheMsgHandlerFactoryAuthStub.java
@@ -17,14 +17,6 @@ public class MemcacheMsgHandlerFactoryAuthStub implements MemcacheMsgHandlerFact
 	}
 
 	@Override
-	public void shutdownNow() {
-	}
-
-	@Override
-	public void shutdown() {
-	}
-
-	@Override
 	public boolean isCacheValid(String cacheName) {
 		return valid;
 	}

--- a/src/test/java/cloudfoundry/memcache/SecretKeyAuthMsgHandlerTest.java
+++ b/src/test/java/cloudfoundry/memcache/SecretKeyAuthMsgHandlerTest.java
@@ -1,6 +1,9 @@
 package cloudfoundry.memcache;
 
-import static org.testng.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -9,13 +12,11 @@ import io.netty.handler.codec.memcache.MemcacheContent;
 import io.netty.handler.codec.memcache.binary.BinaryMemcacheOpcodes;
 import io.netty.handler.codec.memcache.binary.BinaryMemcacheRequest;
 import io.netty.handler.codec.memcache.binary.DefaultBinaryMemcacheRequest;
-
 import java.util.UUID;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.easymock.EasyMock;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 public class SecretKeyAuthMsgHandlerTest {
 

--- a/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheWhalinTest.java
+++ b/src/test/java/cloudfoundry/memcache/hazelcast/HazelcastMemcacheWhalinTest.java
@@ -1,41 +1,33 @@
 package cloudfoundry.memcache.hazelcast;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
-import java.net.ServerSocket;
-import java.util.Collections;
-import java.util.Random;
-
-import org.apache.commons.lang.RandomStringUtils;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import cloudfoundry.memcache.MemcacheMsgHandlerFactory;
-import cloudfoundry.memcache.MemcacheMsgHandlerFactoryAuthStub;
 import cloudfoundry.memcache.MemcacheServer;
 import cloudfoundry.memcache.MemcacheStats;
 import cloudfoundry.memcache.SecretKeyAuthMsgHandlerFactory;
-import cloudfoundry.memcache.StubAuthMsgHandlerFactory;
-import io.netty.util.CharsetUtil;
-
-import com.hazelcast.config.Config;
 import com.schooner.MemCached.AuthInfo;
 import com.schooner.MemCached.SchoonerSockIOPool;
 import com.whalin.MemCached.MemCachedClient;
+import java.net.ServerSocket;
+import java.util.Collections;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 
 public class HazelcastMemcacheWhalinTest {
 
-	MemCachedClient c;
-	MemcacheMsgHandlerFactory factory;
-	SchoonerSockIOPool pool;
+	static MemCachedClient c;
+	static HazelcastMemcacheMsgHandlerFactory factory;
+	static SchoonerSockIOPool pool;
+	static MemcacheServer server;
 
 	@BeforeClass
-	public void setup() throws Exception {
+	public static void setup() throws Exception {
 		System.getProperties().put("io.netty.leakDetectionLevel", "paranoid");
 
 		int localPort = 54913;
@@ -44,11 +36,12 @@ public class HazelcastMemcacheWhalinTest {
 		}
 		System.out.println("Localport: "+localPort);
 
-		MemcacheServer server = new MemcacheServer(localPort, new SecretKeyAuthMsgHandlerFactory("key", "test", "test", "test"), 100, 1000, new MemcacheStats());
 		MemcacheHazelcastConfig appConfig = new MemcacheHazelcastConfig();
 		appConfig.getHazelcast().getMachines().put("local", Collections.singletonList("127.0.0.1"));
 		appConfig.getMemcache().setMaxValueSize(10485760);
-		factory = new HazelcastMemcacheMsgHandlerFactory(server, appConfig);
+		factory = new HazelcastMemcacheMsgHandlerFactory(appConfig);
+
+		server = new MemcacheServer(factory, localPort, new SecretKeyAuthMsgHandlerFactory("key", "test", "test", "test"), 100, 1000, new MemcacheStats());
 
 		while(!factory.status().equals(MemcacheMsgHandlerFactory.OK_STATUS)) {
 			Thread.sleep(1000);
@@ -96,9 +89,10 @@ public class HazelcastMemcacheWhalinTest {
 	}
 	
 	@AfterClass
-	public void after() throws Exception {
+	public static void after() throws Exception {
 		pool.shutDown();
-		factory.shutdown();
+		server.close();
+		factory.close();
 	}
 
 	@Test


### PR DESCRIPTION
Remove Hazelcast Quorum support.  This code was trying to do some fancy stuff like shutdown the memcache server (11211) if the Hazelcast cluster didn't have a minimum number of cluster members and then start it back up when it did reach quorum again without bringing down the server instance in an effort to preserve data in a bad situation.  This greatly complicated the relationship between HazelcastMemcacheMsgHandlerFactory and MemacheServer probably producing a number of shutdown and in a bad state (e.g. not listening on 11211) bugs.

Now that we're just trying to get this service stable to cross the finish line there is no need for fancy stuff.  So, I've ripped out all the quorum stuff and did a full audit of all the startup/shutdown logic to try and reduce potential in this area.  